### PR TITLE
Fix icon not visible for boolean fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `radio-deck` will be documented in this file.
 
+## Version 1.1.0: Added Support for Custom Colors and Code Cleanup - 2024-01-01
+
+Clean up some files, remove unnecessary variables and also make some minor performance nice tip thanks to @ralphjsmit at discord. This release also supports the custom color that will be visible to card ring and icons.
+
+### What's Changed
+
+* Cleanup files by @CodeWithDennis in https://github.com/199ocero/radio-deck/pull/1
+
+### New Contributors
+
+* @CodeWithDennis made their first contribution in https://github.com/199ocero/radio-deck/pull/1
+
+**Full Changelog**: https://github.com/199ocero/radio-deck/compare/v1.0.0-beta...v1.1.0
+
 ## v1.0.0-beta - 2023-12-28
 
 First beta release

--- a/src/Forms/Components/RadioDeck.php
+++ b/src/Forms/Components/RadioDeck.php
@@ -30,7 +30,7 @@ class RadioDeck extends Radio
      */
     public function hasIcons($value): bool
     {
-        if ($value && !empty($this->getIcons())) {
+        if ($value !== null && !empty($this->getIcons())) {
             return array_key_exists($value, $this->getIcons());
         }
 


### PR DESCRIPTION
When you use boolean as values the icon will not be shown.

```php
->icons([
  1 => 'heroicon-m-eye',
  0 => 'heroicon-o-eye-slash',
])
```

What is happening:
<img width="865" alt="Scherm­afbeelding 2024-01-02 om 14 26 07" src="https://github.com/199ocero/radio-deck/assets/23448484/4a87609c-0145-438f-bd51-86883e00a503">

What is expected:
<img width="867" alt="Scherm­afbeelding 2024-01-02 om 14 25 58" src="https://github.com/199ocero/radio-deck/assets/23448484/8bffeb6a-6307-4c08-bef6-495ba44fed5c">

_PS: Ignore the descriptions; I mistakenly switched them._