### PR TITLE
support enums for descriptions and icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,82 @@ public static function form(Form $form): Form
         ->columns('full');
 }
 ```
+You can also utilize an Enum class for `->options()`, `->descriptions()`, and `->icons()` . Here's an example of how to create a simple enum class for this purpose:
+```php
+<?php
+
+namespace App\Filament\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+use JaOcero\RadioDeck\Contracts\HasDescriptions;
+use JaOcero\RadioDeck\Contracts\HasIcons;
+
+enum AssetType: string implements HasLabel, HasDescriptions, HasIcons
+{
+    case iOs = 'ios';
+    case Android = 'android';
+    case Web = 'web';
+    case Windows = 'windows';
+    case Mac = 'mac';
+    case Linux = 'linux';
+
+    public function getLabel(): ?string
+    {
+        return match ($this) {
+            self::iOs => 'iOS',
+            self::Android => 'Android',
+            self::Web => 'Web',
+            self::Windows => 'Windows',
+            self::Mac => 'Mac',
+            self::Linux => 'Linux',
+        };
+    }
+
+    public function getDescriptions(): ?string
+    {
+        return match ($this) {
+            self::iOs => 'iOS Mobile App',
+            self::Android => 'Android Mobile App',
+            self::Web => 'Web App',
+            self::Windows => 'Windows Desktop App',
+            self::Mac => 'Mac Desktop App',
+            self::Linux => 'Linux Desktop App',
+        };
+    }
+
+    public function getIcons(): ?string
+    {
+        return match ($this) {
+            self::iOs => 'heroicon-m-device-phone-mobile',
+            self::Android => 'heroicon-m-device-phone-mobile',
+            self::Web => 'heroicon-m-globe-alt',
+            self::Windows => 'heroicon-m-computer-desktop',
+            self::Mac => 'heroicon-m-computer-desktop',
+            self::Linux => 'heroicon-m-computer-desktop',
+        };
+    }
+}
+```
+After that, in your form, you can set it up like this:
+```php
+public static function form(Form $form): Form
+{
+    return $form
+        ->schema([
+            RadioDeck::make('name')
+                ->options(AssetType::class)
+                ->descriptions(AssetType::class)
+                ->icons(AssetType::class)
+                ->required()
+                ->iconSize(IconSize::Large)
+                ->iconPosition(IconPosition::Before)
+                ->alignment(Alignment::Center)
+                ->color('danger')
+                ->columns(3),
+        ])
+        ->columns('full');
+}
+```
 
 ## Changelog
 

--- a/resources/views/forms/components/radio-deck.blade.php
+++ b/resources/views/forms/components/radio-deck.blade.php
@@ -1,4 +1,8 @@
 @php
+    use Filament\Support\Enums\IconPosition;
+    use Filament\Support\Enums\Alignment;
+    use Filament\Support\Enums\IconSize;
+
     $id = $getId();
     $isDisabled = $isDisabled();
     $statePath = $getStatePath();
@@ -12,86 +16,80 @@
                 $shouldOptionBeDisabled = $isDisabled || $isOptionDisabled($value, $label);
             @endphp
 
-            <x-filament::input.wrapper>
-                <label class="flex cursor-pointer gap-x-3">
-                    <input @disabled($shouldOptionBeDisabled) id="{{ $id }}-{{ $value }}"
-                        name="{{ $id }}" type="radio" value="{{ $value }}" wire:loading.attr="disabled"
-                        {{ $applyStateBindingModifiers('wire:model') }}="{{ $statePath }}"
-                        {{ $getExtraInputAttributeBag()->class(['peer hidden']) }} />
+            <label class="flex cursor-pointer gap-x-3">
+                <input @disabled($shouldOptionBeDisabled) id="{{ $id }}-{{ $value }}"
+                    name="{{ $id }}" type="radio" value="{{ $value }}" wire:loading.attr="disabled"
+                    {{ $applyStateBindingModifiers('wire:model') }}="{{ $statePath }}"
+                    {{ $getExtraInputAttributeBag()->class(['peer hidden']) }} />
 
-                    @php
-                        $iconExists = $hasIcons($value);
-                        $iconPosition = $getIconPosition();
-                        $alignment = $getAlignment();
-                        $color = $getColor();
-                        $icon = $getIcon($value);
-                        $iconSize = $getIconSize();
-                        $descriptionExists = $hasDescription($value);
-                        $description = $getDescription($value);
-                    @endphp
-                    <div @class([
-                        'flex px-4 py-2 w-full text-sm leading-6 rounded-lg gap-5',
-                        $iconExists
-                            ? match ($iconPosition) {
-                                \Filament\Support\Enums\IconPosition::Before,
-                                'before'
-                                    => 'justify-start',
-                                \Filament\Support\Enums\IconPosition::After,
-                                'after'
-                                    => 'justify-between flex-row-reverse',
-                                default => 'justify-start',
-                            }
-                            : 'justify-start',
-                        match ($alignment) {
-                            \Filament\Support\Enums\Alignment::Center, 'center' => 'items-center',
-                            \Filament\Support\Enums\Alignment::Start, 'start' => 'items-start',
-                            \Filament\Support\Enums\Alignment::End, 'end' => 'items-end',
-                            default => 'items-center',
-                        },
-                        'ring-1 ring-gray-200 dark:ring-gray-700 peer-checked:ring-2',
-                        'peer-disabled:bg-gray-100/50 dark:peer-disabled:bg-gray-700/50 peer-disabled:cursor-not-allowed',
-                        match ($color) {
-                            'gray' => 'peer-checked:ring-gray-600 dark:peer-checked:ring-gray-700',
-                            default
-                                => 'fi-color-custom peer-checked:ring-custom-600 dark:peer-checked:ring-custom-700',
-                        },
-                    ]) @style([
-                        \Filament\Support\get_color_css_variables($color, shades: [600, 700]) => $color !== 'gray',
-                    ])>
-                        @if ($iconExists)
-                            <x-filament::icon :icon="$icon" @class([
-                                'flex-shrink-0',
-                                match ($iconSize) {
-                                    \Filament\Support\Enums\IconSize::Small => 'h-8 w-8',
-                                    'sm' => 'h-8 w-8',
-                                    \Filament\Support\Enums\IconSize::Medium => 'h-9 w-9',
-                                    'md' => 'h-9 w-9',
-                                    \Filament\Support\Enums\IconSize::Large => 'h-10 w-10',
-                                    'lg' => 'h-10 w-10',
-                                    default => 'h-8 w-8',
-                                },
-                                match ($color) {
-                                    'gray' => 'fi-color-gray text-gray-600 dark:text-gray-500',
-                                    default => 'fi-color-custom text-custom-600 dark:text-custom-500',
-                                },
-                            ]) @style([
-                                \Filament\Support\get_color_css_variables($color, shades: [600, 500]) => $color !== 'gray',
-                            ]) />
+                @php
+                    $iconExists = $hasIcons($value);
+                    $iconPosition = $getIconPosition();
+                    $alignment = $getAlignment();
+                    $color = $getColor();
+                    $icon = $getIcon($value);
+                    $iconSize = $getIconSize();
+                    $descriptionExists = $hasDescription($value);
+                    $description = $getDescription($value);
+                @endphp
+                <div @class([
+                    'flex px-4 py-2 w-full text-sm leading-6 rounded-lg gap-5 bg-white dark:bg-gray-900',
+                    $iconExists
+                        ? match ($iconPosition) {
+                            IconPosition::Before, 'before' => 'justify-start',
+                            IconPosition::After, 'after' => 'justify-between flex-row-reverse',
+                            default => 'justify-start',
+                        }
+                        : 'justify-start',
+                    match ($alignment) {
+                        Alignment::Center, 'center' => 'items-center',
+                        Alignment::Start, 'start' => 'items-start',
+                        Alignment::End, 'end' => 'items-end',
+                        default => 'items-center',
+                    },
+                    'ring-1 ring-gray-200 dark:ring-gray-700 peer-checked:ring-2',
+                    'peer-disabled:bg-gray-100/50 dark:peer-disabled:bg-gray-700/50 peer-disabled:cursor-not-allowed',
+                    match ($color) {
+                        'gray' => 'peer-checked:ring-gray-600 dark:peer-checked:ring-gray-700',
+                        default
+                            => 'fi-color-custom peer-checked:ring-custom-600 dark:peer-checked:ring-custom-700',
+                    },
+                ]) @style([
+                    \Filament\Support\get_color_css_variables($color, shades: [600, 700]) => $color !== 'gray',
+                ])>
+                    @if ($iconExists)
+                        <x-filament::icon :icon="$icon" @class([
+                            'flex-shrink-0',
+                            match ($iconSize) {
+                                IconSize::Small => 'h-8 w-8',
+                                'sm' => 'h-8 w-8',
+                                IconSize::Medium => 'h-9 w-9',
+                                'md' => 'h-9 w-9',
+                                IconSize::Large => 'h-10 w-10',
+                                'lg' => 'h-10 w-10',
+                                default => 'h-8 w-8',
+                            },
+                            match ($color) {
+                                'gray' => 'fi-color-gray text-gray-600 dark:text-gray-500',
+                                default => 'fi-color-custom text-custom-600 dark:text-custom-500',
+                            },
+                        ]) @style([
+                            \Filament\Support\get_color_css_variables($color, shades: [600, 500]) => $color !== 'gray',
+                        ]) />
+                    @endif
+                    <div class="place-items-start">
+                        <span class="font-medium text-gray-950 dark:text-white">
+                            {{ $label }}
+                        </span>
+
+                        @if ($descriptionExists)
+                            <p class="text-gray-500 dark:text-gray-400">
+                                {{ $description }}
+                            </p>
                         @endif
-                        <div class="place-items-start">
-                            <span class="font-medium text-gray-950 dark:text-white">
-                                {{ $label }}
-                            </span>
-
-                            @if ($descriptionExists)
-                                <p class="text-gray-500 dark:text-gray-400">
-                                    {{ $description }}
-                                </p>
-                            @endif
-                        </div>
                     </div>
-                </label>
-            </x-filament::input.wrapper>
+                </div>
+            </label>
         @endforeach
     </x-filament::grid>
 </x-dynamic-component>

--- a/src/Contracts/HasDescriptions.php
+++ b/src/Contracts/HasDescriptions.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace JaOcero\RadioDeck\Contracts;
+
+interface HasDescriptions
+{
+    public function getDescriptions(): ?string;
+}

--- a/src/Contracts/HasIcons.php
+++ b/src/Contracts/HasIcons.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace JaOcero\RadioDeck\Contracts;
+
+interface HasIcons
+{
+    public function getIcons(): ?string;
+}

--- a/src/Forms/Components/RadioDeck.php
+++ b/src/Forms/Components/RadioDeck.php
@@ -3,10 +3,9 @@
 namespace JaOcero\RadioDeck\Forms\Components;
 
 use Closure;
-use Filament\Forms\Components\Radio;
-use Filament\Support\Concerns\HasIcon;
-use Filament\Support\Concerns\HasColor;
 use Filament\Support\Concerns\HasAlignment;
+use Filament\Support\Concerns\HasColor;
+use Filament\Support\Concerns\HasIcon;
 use Illuminate\Contracts\Support\Arrayable;
 use JaOcero\RadioDeck\Contracts\HasDescriptions;
 use JaOcero\RadioDeck\Contracts\HasIcons;
@@ -18,20 +17,20 @@ class RadioDeck extends IntermediaryRadio
     use HasColor;
     use HasIcon;
 
-    protected array | Arrayable | string | Closure | null $icons = null;
+    protected array|Arrayable|string|Closure|null $icons = null;
 
-    protected array | Arrayable | string | Closure $descriptions = [];
+    protected array|Arrayable|string|Closure $descriptions = [];
 
     protected string $view = 'radio-deck::forms.components.radio-deck';
 
-    public function icons(array | Arrayable | string | Closure | null $icons): static
+    public function icons(array|Arrayable|string|Closure|null $icons): static
     {
         $this->icons = $icons;
 
         return $this;
     }
 
-    public function descriptions(array | Arrayable | string | Closure $descriptions): static
+    public function descriptions(array|Arrayable|string|Closure $descriptions): static
     {
         $this->descriptions = $descriptions;
 
@@ -43,7 +42,7 @@ class RadioDeck extends IntermediaryRadio
      */
     public function hasIcons($value): bool
     {
-        if ($value !== null && !empty($this->getIcons())) {
+        if ($value !== null && ! empty($this->getIcons())) {
             return array_key_exists($value, $this->getIcons());
         }
 

--- a/src/Intermediary/IntermediaryRadio.php
+++ b/src/Intermediary/IntermediaryRadio.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace JaOcero\RadioDeck\Intermediary;
+
+use Closure;
+
+use Filament\Forms\Components\Field;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Support\Arrayable;
+use Filament\Forms\Components\Concerns\HasOptions;
+use Filament\Forms\Components\Concerns\HasGridDirection;
+use Filament\Forms\Components\Concerns\CanFixIndistinctState;
+use Filament\Forms\Components\Concerns\HasExtraInputAttributes;
+use Filament\Forms\Components\Concerns\CanDisableOptions as ConcernCanDisableOptions;
+use Filament\Forms\Components\Contracts\CanDisableOptions as ContractsCanDisableOptions;
+use Filament\Forms\Components\Concerns\CanDisableOptionsWhenSelectedInSiblingRepeaterItems;
+
+class IntermediaryRadio extends Field implements ContractsCanDisableOptions
+{
+    use ConcernCanDisableOptions;
+    use CanDisableOptionsWhenSelectedInSiblingRepeaterItems;
+    use CanFixIndistinctState;
+    use HasExtraInputAttributes;
+    use HasGridDirection;
+    use HasOptions;
+
+    protected array | string | Arrayable | Closure $descriptions = [];
+
+    /**
+     * @param  array<string | Htmlable> | Arrayable | string | Closure  $descriptions
+     */
+    public function descriptions(array | Arrayable | string | Closure $descriptions): static
+    {
+        $this->descriptions = $descriptions;
+
+        return $this;
+    }
+
+    /**
+     * @param  array-key  $value
+     */
+    public function hasDescription($value): bool
+    {
+        return array_key_exists($value, $this->getDescriptions());
+    }
+
+    /**
+     * @param  array-key  $value
+     */
+    public function getDescription($value): string | Htmlable | null
+    {
+        return $this->getDescriptions()[$value] ?? null;
+    }
+
+    /**
+     * @return array<string | Htmlable>
+     */
+    public function getDescriptions(): array
+    {
+        $descriptions = $this->evaluate($this->descriptions);
+
+        if ($descriptions instanceof Arrayable) {
+            $descriptions = $descriptions->toArray();
+        }
+
+        return $descriptions;
+    }
+
+    public function getDefaultState(): mixed
+    {
+        $state = parent::getDefaultState();
+
+        if (is_bool($state)) {
+            return $state ? 1 : 0;
+        }
+
+        return $state;
+    }
+}

--- a/src/Intermediary/IntermediaryRadio.php
+++ b/src/Intermediary/IntermediaryRadio.php
@@ -3,33 +3,32 @@
 namespace JaOcero\RadioDeck\Intermediary;
 
 use Closure;
-
-use Filament\Forms\Components\Field;
-use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Contracts\Support\Arrayable;
-use Filament\Forms\Components\Concerns\HasOptions;
-use Filament\Forms\Components\Concerns\HasGridDirection;
+use Filament\Forms\Components\Concerns\CanDisableOptions as ConcernCanDisableOptions;
+use Filament\Forms\Components\Concerns\CanDisableOptionsWhenSelectedInSiblingRepeaterItems;
 use Filament\Forms\Components\Concerns\CanFixIndistinctState;
 use Filament\Forms\Components\Concerns\HasExtraInputAttributes;
-use Filament\Forms\Components\Concerns\CanDisableOptions as ConcernCanDisableOptions;
+use Filament\Forms\Components\Concerns\HasGridDirection;
+use Filament\Forms\Components\Concerns\HasOptions;
 use Filament\Forms\Components\Contracts\CanDisableOptions as ContractsCanDisableOptions;
-use Filament\Forms\Components\Concerns\CanDisableOptionsWhenSelectedInSiblingRepeaterItems;
+use Filament\Forms\Components\Field;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Htmlable;
 
 class IntermediaryRadio extends Field implements ContractsCanDisableOptions
 {
-    use ConcernCanDisableOptions;
     use CanDisableOptionsWhenSelectedInSiblingRepeaterItems;
     use CanFixIndistinctState;
+    use ConcernCanDisableOptions;
     use HasExtraInputAttributes;
     use HasGridDirection;
     use HasOptions;
 
-    protected array | string | Arrayable | Closure $descriptions = [];
+    protected array|string|Arrayable|Closure $descriptions = [];
 
     /**
      * @param  array<string | Htmlable> | Arrayable | string | Closure  $descriptions
      */
-    public function descriptions(array | Arrayable | string | Closure $descriptions): static
+    public function descriptions(array|Arrayable|string|Closure $descriptions): static
     {
         $this->descriptions = $descriptions;
 
@@ -47,7 +46,7 @@ class IntermediaryRadio extends Field implements ContractsCanDisableOptions
     /**
      * @param  array-key  $value
      */
-    public function getDescription($value): string | Htmlable | null
+    public function getDescription($value): string|Htmlable|null
     {
         return $this->getDescriptions()[$value] ?? null;
     }


### PR DESCRIPTION
For enhancement: Support Enums for `->descriptions()` and `->icons()` . Enhancement [#5](https://github.com/199ocero/radio-deck/issues/4)