### PR TITLE
Additional methods to allow more customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ public static function form(Form $form): Form
                 ->iconSize(IconSize::Large) // Small | Medium | Large | (string - sm | md | lg)
                 ->iconPosition(IconPosition::Before) // Before | After | (string - before | after)
                 ->alignment(Alignment::Center) // Start | Center | End | (string - start | center | end)
+                ->gap('gap-5') // Gap between Icon and Description (Any TailwindCSS gap-* utility)
+                ->padding('px-4 px-6') // Padding around the deck (Any TailwindCSS padding utility)
+                ->extraOptionsAttributes([ // Extra Attributes to add to the option HTML element
+                    'class' => 'text-3xl leading-none w-full flex flex-col items-center justify-center p-4'
+                ])
+                ->extraDescriptionsAttributes([ // Extra Attributes to add to the description HTML element
+                    'class' => 'text-sm font-light text-center'
+                ])
                 ->color('primary') // supports all color custom or not
                 ->columns(3)
         ])

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ public static function form(Form $form): Form
                 ->alignment(Alignment::Center) // Start | Center | End | (string - start | center | end)
                 ->gap('gap-5') // Gap between Icon and Description (Any TailwindCSS gap-* utility)
                 ->padding('px-4 px-6') // Padding around the deck (Any TailwindCSS padding utility)
+                ->direction('column') // Column | Row (Allows to place the Icon on top)
                 ->extraOptionsAttributes([ // Extra Attributes to add to the option HTML element
                     'class' => 'text-3xl leading-none w-full flex flex-col items-center justify-center p-4'
                 ])

--- a/resources/views/forms/components/radio-deck.blade.php
+++ b/resources/views/forms/components/radio-deck.blade.php
@@ -26,6 +26,9 @@
                     $iconExists = $hasIcons($value);
                     $iconPosition = $getIconPosition();
                     $alignment = $getAlignment();
+                    $direction = $getDirection();
+                    $gap = $getGap();
+                    $padding = $getPadding();
                     $color = $getColor();
                     $icon = $getIcon($value);
                     $iconSize = $getIconSize();
@@ -33,7 +36,13 @@
                     $description = $getDescription($value);
                 @endphp
                 <div @class([
-                    'flex px-4 py-2 w-full text-sm leading-6 rounded-lg gap-5 bg-white dark:bg-gray-900',
+                    'flex w-full text-sm leading-6 rounded-lg bg-white dark:bg-gray-900',
+                    $padding ?: 'px-4 py-2',
+                    $gap ?: 'gap-5',
+                    match ($direction) {
+                        'column' => 'flex-col',
+                        default => 'flex-row',
+                    },
                     $iconExists
                         ? match ($iconPosition) {
                             IconPosition::Before, 'before' => 'justify-start',
@@ -77,13 +86,13 @@
                             \Filament\Support\get_color_css_variables($color, shades: [600, 500]) => $color !== 'gray',
                         ]) />
                     @endif
-                    <div class="place-items-start">
+                    <div {{ $getExtraOptionsAttributeBag()->merge(['class' =>'place-items-start']) }}>
                         <span class="font-medium text-gray-950 dark:text-white">
                             {{ $label }}
                         </span>
 
                         @if ($descriptionExists)
-                            <p class="text-gray-500 dark:text-gray-400">
+                            <p {{ $getExtraDescriptionsAttributeBag()->merge(['class' =>'text-gray-500 dark:text-gray-400']) }}>
                                 {{ $description }}
                             </p>
                         @endif

--- a/src/Forms/Components/RadioDeck.php
+++ b/src/Forms/Components/RadioDeck.php
@@ -10,12 +10,22 @@ use Illuminate\Contracts\Support\Arrayable;
 use JaOcero\RadioDeck\Contracts\HasDescriptions;
 use JaOcero\RadioDeck\Contracts\HasIcons;
 use JaOcero\RadioDeck\Intermediary\IntermediaryRadio;
+use JaOcero\RadioDeck\Traits\HasDirection;
+use JaOcero\RadioDeck\Traits\HasExtraDescriptionsAttributes;
+use JaOcero\RadioDeck\Traits\HasExtraOptionsAttributes;
+use JaOcero\RadioDeck\Traits\HasGap;
+use JaOcero\RadioDeck\Traits\HasPadding;
 
 class RadioDeck extends IntermediaryRadio
 {
     use HasAlignment;
     use HasColor;
     use HasIcon;
+    use HasGap;
+    use HasPadding;
+    use HasDirection;
+    use HasExtraOptionsAttributes;
+    use HasExtraDescriptionsAttributes;
 
     protected array|Arrayable|string|Closure|null $icons = null;
 

--- a/src/Traits/HasDirection.php
+++ b/src/Traits/HasDirection.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace JaOcero\RadioDeck\Traits;
+
+use Filament\Support\Enums\IconPosition;
+use Filament\Support\Enums\IconSize;
+
+trait HasDirection
+{
+    protected string|Closure|null $direction = null;
+
+    public function direction(string|Closure|null $direction): static
+    {
+        $this->direction = $direction;
+
+        return $this;
+    }
+
+    public function getDirection(): ?string
+    {
+        return $this->evaluate($this->direction);
+    }
+
+}

--- a/src/Traits/HasExtraDescriptionsAttributes.php
+++ b/src/Traits/HasExtraDescriptionsAttributes.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace JaOcero\RadioDeck\Traits;
+
+use Illuminate\View\ComponentAttributeBag;
+
+trait HasExtraDescriptionsAttributes
+{
+    /**
+     * @var array<array<mixed> | Closure>
+     */
+    protected array $extraDescriptionsAttributes = [];
+
+    /**
+     * @param  array<mixed> | Closure  $attributes
+     */
+    public function extraDescriptionsAttributes(array | Closure $attributes, bool $merge = false): static
+    {
+        if ($merge) {
+            $this->extraDescriptionsAttributes[] = $attributes;
+        } else {
+            $this->extraDescriptionsAttributes = [$attributes];
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getExtraDescriptionsAttributes(): array
+    {
+        $temporaryAttributeBag = new ComponentAttributeBag();
+
+        foreach ($this->extraDescriptionsAttributes as $extraDescriptionsAttributes) {
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraDescriptionsAttributes));
+        }
+
+        return $temporaryAttributeBag->getAttributes();
+    }
+
+    public function getExtraDescriptionsAttributeBag(): ComponentAttributeBag
+    {
+        return new ComponentAttributeBag($this->getExtraDescriptionsAttributes());
+    }
+}

--- a/src/Traits/HasExtraOptionsAttributes.php
+++ b/src/Traits/HasExtraOptionsAttributes.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace JaOcero\RadioDeck\Traits;
+
+use Illuminate\View\ComponentAttributeBag;
+
+trait HasExtraOptionsAttributes
+{
+    /**
+     * @var array<array<mixed> | Closure>
+     */
+    protected array $extraOptionsAttributes = [];
+
+    /**
+     * @param  array<mixed> | Closure  $attributes
+     */
+    public function extraOptionsAttributes(array | Closure $attributes, bool $merge = false): static
+    {
+        if ($merge) {
+            $this->extraOptionsAttributes[] = $attributes;
+        } else {
+            $this->extraOptionsAttributes = [$attributes];
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getExtraOptionsAttributes(): array
+    {
+        $temporaryAttributeBag = new ComponentAttributeBag();
+
+        foreach ($this->extraOptionsAttributes as $extraOptionsAttributes) {
+            $temporaryAttributeBag = $temporaryAttributeBag->merge($this->evaluate($extraOptionsAttributes));
+        }
+
+        return $temporaryAttributeBag->getAttributes();
+    }
+
+    public function getExtraOptionsAttributeBag(): ComponentAttributeBag
+    {
+        return new ComponentAttributeBag($this->getExtraOptionsAttributes());
+    }
+}

--- a/src/Traits/HasGap.php
+++ b/src/Traits/HasGap.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace JaOcero\RadioDeck\Traits;
+
+use Filament\Support\Enums\IconPosition;
+use Filament\Support\Enums\IconSize;
+
+trait HasGap
+{
+    protected string|Closure|null $gap = null;
+
+    public function gap(string|Closure|null $gap): static
+    {
+        $this->gap = $gap;
+
+        return $this;
+    }
+
+    public function getGap(): ?string
+    {
+        return $this->evaluate($this->gap);
+    }
+
+}

--- a/src/Traits/HasPadding.php
+++ b/src/Traits/HasPadding.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace JaOcero\RadioDeck\Traits;
+
+use Filament\Support\Enums\IconPosition;
+use Filament\Support\Enums\IconSize;
+
+trait HasPadding
+{
+    protected string|Closure|null $padding = null;
+
+    public function padding(string|Closure|null $padding): static
+    {
+        $this->padding = $padding;
+
+        return $this;
+    }
+
+    public function getPadding(): ?string
+    {
+        return $this->evaluate($this->padding);
+    }
+
+}


### PR DESCRIPTION
This plugin is really great but I needed a little bit more customization options.  

I've added methods to:
- Manage the HTML attributes for the Option element
- Manage the HTML attributes for the Description element
- Manage the padding of the decks
- Manage the Flex Direction of the decks
- Manage the gap between the Icon and the Texts.