### PR TITLE
Adds checkbox multiple support

### DIFF
--- a/resources/views/forms/components/radio-deck.blade.php
+++ b/resources/views/forms/components/radio-deck.blade.php
@@ -5,6 +5,7 @@
 
     $id = $getId();
     $isDisabled = $isDisabled();
+    $isMultiple = $isMultiple();
     $statePath = $getStatePath();
 @endphp
 
@@ -18,7 +19,9 @@
 
             <label class="flex cursor-pointer gap-x-3">
                 <input @disabled($shouldOptionBeDisabled) id="{{ $id }}-{{ $value }}"
-                    name="{{ $id }}" type="radio" value="{{ $value }}" wire:loading.attr="disabled"
+                    name="{{ $id }}"
+                    type="{{  $isMultiple ? 'checkbox' : 'radio' }}"
+                    value="{{ $value }}" wire:loading.attr="disabled"
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $statePath }}"
                     {{ $getExtraInputAttributeBag()->class(['peer hidden']) }} />
 

--- a/src/Forms/Components/RadioDeck.php
+++ b/src/Forms/Components/RadioDeck.php
@@ -2,6 +2,7 @@
 
 namespace JaOcero\RadioDeck\Forms\Components;
 
+use App\Filament\Fields\CheckboxDeck;
 use Closure;
 use Filament\Support\Concerns\HasAlignment;
 use Filament\Support\Concerns\HasColor;
@@ -36,7 +37,16 @@ class RadioDeck extends IntermediaryRadio
 
     protected array|Arrayable|Closure|string $descriptions = [];
 
+    protected bool|Closure $isMultiple = false;
+
     protected string $view = 'radio-deck::forms.components.radio-deck';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->default(fn (RadioDeck $component): mixed => $component->isMultiple() ? [] : null);
+    }
 
     public function icons(array|Arrayable|string|Closure|null $icons): static
     {
@@ -48,6 +58,13 @@ class RadioDeck extends IntermediaryRadio
     public function descriptions(array|Arrayable|string|Closure $descriptions): static
     {
         $this->descriptions = $descriptions;
+
+        return $this;
+    }
+
+    public function multiple(bool|Closure $condition = true): static
+    {
+        $this->isMultiple = $condition;
 
         return $this;
     }
@@ -131,5 +148,10 @@ class RadioDeck extends IntermediaryRadio
         }
 
         return $descriptions;
+    }
+
+    public function isMultiple(): bool
+    {
+        return (bool) $this->evaluate($this->isMultiple);
     }
 }


### PR DESCRIPTION
This allows you to call `RadioDeck::make('items')->multiple()` to change the field to a checkbox and select many options. 

I basically duplicated exactly how the filament `ToggleButtons` field handles it. 