### PR TITLE
Update RadioDeck.php [Hint Support Added!]

### DIFF
--- a/src/Forms/Components/RadioDeck.php
+++ b/src/Forms/Components/RadioDeck.php
@@ -3,6 +3,7 @@
 namespace JaOcero\RadioDeck\Forms\Components;
 
 use Closure;
+use Filament\Forms\Components\Concerns\HasHint;
 use Filament\Support\Concerns\HasAlignment;
 use Filament\Support\Concerns\HasColor;
 use Filament\Support\Concerns\HasIcon;
@@ -31,6 +32,7 @@ class RadioDeck extends IntermediaryRadio
     use HasIcon;
     use HasIconSizes;
     use HasPadding;
+    use HasHint;
 
     protected array|Arrayable|Closure|string|null $icons = null;
 


### PR DESCRIPTION
💡 Hint Support Added!
RadioDeck now supports Hints using Filament's built-in HasHint trait. *
✅ You can now attach hints to your RadioDeck component using:
 `->hint('This is a helpful message for the user.')`

 ✅ You can also make your hints interactive using:
```
 ->hintAction(
  Action::make('add')
          ->label('Add Option')
          ->icon('heroicon-m-plus')
          ->action(fn () => /* Your logic here */)
 )
```
This is useful for:
 - Showing additional information or tooltips
 - Linking to more settings or docs-
 -  Adding custom actions like “Create New Option” in-line
