### PR TITLE
fix: icon size & support BackedEnum

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ use JaOcero\RadioDeck\Forms\Components\RadioDeck;
 use Filament\Support\Enums\IconSize;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Enums\IconPosition;
+use Filament\Support\Icons\Heroicon;
 
 public static function form(Form $form): Form
 {
@@ -132,7 +133,7 @@ public static function form(Form $form): Form
                     'linux' => 'Linux Desktop App',
                 ])
                 ->icons([
-                    'ios' => 'heroicon-m-device-phone-mobile',
+                    'ios' => Heroicon::DevicePhoneMobile,
                     'android' => 'heroicon-m-device-phone-mobile',
                     'web' => 'heroicon-m-globe-alt',
                     'windows' => 'heroicon-m-computer-desktop',
@@ -140,7 +141,7 @@ public static function form(Form $form): Form
                     'linux' => 'heroicon-m-computer-desktop',
                 ])
                 ->required()
-                ->iconSizes(IconSize::Medium) // Medium | Small | Large | ExtraLarge | TwoExtraLarge
+                ->iconSizes(IconSize::Medium) // Medium | Small | Large | ExtraLarge | TwoExtraLarge or string value like 'md' | 'sm' | 'lg' | 'xl' | '2xl'
                 ->iconPosition(IconPosition::Before) // Before | After
                 ->alignment(Alignment::Center) // Start | Center | End
                 ->optionGap('gap-5') // Gap between Options and Descriptions between the Icon
@@ -183,6 +184,7 @@ You can also utilize an Enum class for `->options()`, `->descriptions()`, and `-
 
 namespace App\Filament\Enums;
 
+use BackedEnum;
 use Filament\Support\Contracts\HasLabel;
 use JaOcero\RadioDeck\Contracts\HasDescriptions;
 use JaOcero\RadioDeck\Contracts\HasIcons;
@@ -220,10 +222,10 @@ enum AssetType: string implements HasLabel, HasDescriptions, HasIcons
         };
     }
 
-    public function getIcons(): ?string
+    public function getIcons(): string | BackedEnum | null
     {
         return match ($this) {
-            self::iOs => 'heroicon-m-device-phone-mobile',
+            self::iOs => Heroicon::DevicePhoneMobile,
             self::Android => 'heroicon-m-device-phone-mobile',
             self::Web => 'heroicon-m-globe-alt',
             self::Windows => 'heroicon-m-computer-desktop',

--- a/resources/views/forms/components/radio-deck.blade.php
+++ b/resources/views/forms/components/radio-deck.blade.php
@@ -62,22 +62,11 @@
                     ])>
                     @if ($iconExists)
                         @php
-                            $iconSizeValue = $getIconSize() ?? 'md';
-
-                            $iconSizeClass = match ($iconSizeValue) {
-                                'xs' => 'h-4 w-4',
-                                'sm' => 'h-5 w-5',
-                                'md' => 'h-6 w-6',
-                                'lg' => 'h-8 w-8',
-                                'xl' => 'h-10 w-10',
-                                '2xl' => 'h-12 w-12',
-                                default => $iconSizeValue,
-                            };
+                            $iconSizeValue = $getIconSize() ?? IconSize::Medium;
                         @endphp
 
-                        <x-filament::icon :icon="$icon" @class([
+                        <x-filament::icon :icon="$icon" :size="$iconSizeValue" @class([
                             'flex-shrink-0',
-                            $iconSizeClass,
                             match ($color) {
                                 'gray' => 'fi-color-gray text-gray-600 dark:text-gray-500',
                                 default => 'fi-color-custom text-custom-600 dark:text-custom-500',

--- a/src/Contracts/HasIcons.php
+++ b/src/Contracts/HasIcons.php
@@ -2,7 +2,10 @@
 
 namespace JaOcero\RadioDeck\Contracts;
 
+use BackedEnum;
+use Illuminate\Contracts\Support\Htmlable;
+
 interface HasIcons
 {
-    public function getIcons(): ?string;
+    public function getIcons(): string | BackedEnum | Htmlable | null;
 }

--- a/src/Forms/Components/RadioDeck.php
+++ b/src/Forms/Components/RadioDeck.php
@@ -2,6 +2,7 @@
 
 namespace JaOcero\RadioDeck\Forms\Components;
 
+use BackedEnum;
 use Closure;
 use Filament\Support\Concerns\HasAlignment;
 use Filament\Support\Concerns\HasIcon;
@@ -124,7 +125,7 @@ class RadioDeck extends IntermediaryRadio
         return $icons;
     }
 
-    public function getIcon($value): ?string
+    public function getIcon($value): string | BackedEnum | null
     {
         return $this->getIcons()[$value] ?? null;
     }

--- a/src/Traits/HasIconSize.php
+++ b/src/Traits/HasIconSize.php
@@ -12,7 +12,7 @@ trait HasIconSize
     /**
      * Define the size of the icon.
      *
-     * @param  string|IconSize|Closure|null  $size  The icon size (e.g., IconSize::Medium, 'lg', 'h-12 w-12').
+     * @param  string|IconSize|Closure|null  $size  The icon size (e.g., IconSize::Medium, 'lg').
      */
     public function iconSize(string|IconSize|Closure|null $size): static
     {
@@ -21,14 +21,14 @@ trait HasIconSize
         return $this;
     }
 
-    public function getIconSize(): ?string
+    public function getIconSize(): string|IconSize|null
     {
         $size = $this->evaluate($this->iconSize);
 
-        if ($size instanceof IconSize) {
-            return $size->value;
+        if (! is_string($size)) {
+            return $size;
         }
 
-        return $size;
+        return IconSize::tryFrom($size) ?? $size;
     }
 }


### PR DESCRIPTION
Because the Filament icon component generates the classes ```fi-icon``` and ```fi-size-{$size->value}```, it's no longer necessary to use the ```$iconSizeClass``` variable in ```radio-deck.blade.php```

Instead, you can directly pass the desired size to size attribute of the component.

```blade
<x-filament::icon :icon="$icon" :size="$iconSizeValue" @class([
    'flex-shrink-0',
    match ($color) {
        'gray' => 'fi-color-gray text-gray-600 dark:text-gray-500',
        default => 'fi-color-custom text-custom-600 dark:text-custom-500',
    },
]) @style([
    \Filament\Support\get_color_css_variables($color, shades: [600, 500]) => $color !== 'gray',
]) />
```

Indeed, without this fix, if the size 2xl was defined, the component's generated class remained ```fi-size-md``` and not ```fi-size-2xl```. And so the icon wasn't the right size.

And with the Filament CSS icon class definitions, the sizes are correctly defined.

See ```filament/packages/support/resources/css/components/icon.css```file.

Furthermore, this pull request allows the use of icons with backed enums.

The readme file has been updated accordingly.
Thanks
